### PR TITLE
Cache Node packages in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "18"
+          cache: npm
       - run: npm ci
       - run: npm run build
       - run: npm run type-check


### PR DESCRIPTION
- `~/.npm` をキャッシュするようにしました。これにより、`npm ci` の時間が 3 割削減できます。