### PR TITLE
Cache `.cache` and `public` in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,13 @@ jobs:
         with:
           node-version: "18"
       - run: npm ci
+      - uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-gatsby-build-${{ github.run_id }}
+          path: |
+            .cache
+            public
+          restore-keys: ${{ runner.os }}-gatsby-build-
       - run: npm run build
       - run: npm run type-check
       - run: npm run lint


### PR DESCRIPTION
- `.cache` と `public` をキャッシュするようにしました。これで、ビルド時間が 9 割削減できます。今まで 6 分ほどかかっていましたが、#30 と合わせてこれで 2 分ほどに短縮されます。