### PR TITLE
Fix padding of donation

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -202,7 +202,7 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
         </div>
       </section>
       <section>
-        <div className="container mx-auto py-12">
+        <div className="container mx-auto px-8 py-12">
           <SectionHeader title="ご寄付のお願い" />
           <div className="prose max-w-none mt-8 text-center">
             <p>


### PR DESCRIPTION
- 「ご寄附のお願い」のページのパディングを直しました。

Before
<img width="337" alt="Screenshot 2023-06-24 at 17 25 08" src="https://github.com/ut-code/website/assets/104971044/f0812f38-7124-4250-96b6-cf9ad7f48188">

After
<img width="337" alt="Screenshot 2023-06-24 at 17 26 47" src="https://github.com/ut-code/website/assets/104971044/044cb840-a7fd-44ef-af58-8ffb664de4fc">

related with #32.
