### PR TITLE
Fix slug of summer design lecture announcement

### DIFF
--- a/contents/articles/2023-08-29_design-workshop/index.mdx
+++ b/contents/articles/2023-08-29_design-workshop/index.mdx
@@ -4,7 +4,7 @@ date: 2023-09-26T23:25:00+09:00
 categories:
   - "events"
 image: ./image.png
-slug: summer-design-lecture
+slug: summer-design-lecture-report
 ---
 
 「デザインをそれっぽく見せる方法」というタイトルで、WebアプリのUIデザインを学ぶ講習会を開催しました！


### PR DESCRIPTION
slug被って別の記事が同じ場所に遷移しちゃってました。