### PR TITLE
Google 検索のリッチリザルトに対応

### DIFF
--- a/src/components/CommonHead.tsx
+++ b/src/components/CommonHead.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { Thing } from "schema-dts";
+import type { WithContext, Thing } from "schema-dts";
 import faviconImage from "../images/favicon.png";
 import config from "../../gatsby-config";
 
@@ -12,7 +12,7 @@ export default function CommonHead({
   title: string | null;
   description?: string;
   image?: string;
-  linkedData?: Thing;
+  linkedData?: WithContext<Thing>;
 }) {
   return (
     <>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -257,7 +257,7 @@ export function Head() {
           postalCode: "153-8902",
           addressRegion: "東京都",
           addressLocality: "目黒区",
-          streetAddress: "3-8-1 学生会館 313B",
+          streetAddress: "駒場3-8-1 学生会館 313B",
         },
         foundingDate: "2019-03-22",
       }}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,7 @@ import GlobalFooter from "../components/GlobalFooter";
 import ProjectList from "../components/ProjectList";
 import ArticleList from "../components/ArticleList";
 import CommonHead from "../components/CommonHead";
+import favicon from "../images/favicon.png";
 
 function SectionHeader({
   title,
@@ -242,6 +243,24 @@ export function Head() {
     <CommonHead
       title={null}
       description="ut.code(); は 2019 年設立の東京大学のソフトウェアエンジニアリングコミュニティです。"
+      linkedData={{
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        name: "ut.code();",
+        description:
+          "東京大学のソフトウェアエンジニアリングコミュニティ・プログラミングサークル",
+        logo: favicon,
+        url: "https://utcode.net/",
+        address: {
+          "@type": "PostalAddress",
+          addressCountry: "JP",
+          postalCode: "153-8902",
+          addressRegion: "東京都",
+          addressLocality: "目黒区",
+          streetAddress: "3-8-1 学生会館 313B",
+        },
+        foundingDate: "2019-03-22",
+      }}
     />
   );
 }

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -91,13 +91,16 @@ export function Head({ data }: HeadProps<Queries.ArticlePageQuery>) {
         data.mdx?.frontmatter?.image?.childImageSharp?.resize?.src ?? undefined
       }
       linkedData={{
+        "@context": "https://schema.org",
         "@type": "Article",
         headline: title,
+        image: data.mdx?.frontmatter?.image?.publicURL ?? undefined,
         datePublished: date.toISOString(),
         author: data.mdx?.frontmatter?.author?.frontmatter?.nameJa
           ? {
               "@type": "Person",
               name: data.mdx.frontmatter.author.frontmatter.nameJa,
+              url: `/members/${data.mdx.frontmatter.author.frontmatter.slug}`,
             }
           : undefined,
       }}
@@ -112,6 +115,7 @@ export const query = graphql`
         title
         date
         image {
+          publicURL
           childImageSharp {
             gatsbyImageData(
               width: 1920

--- a/src/templates/member.tsx
+++ b/src/templates/member.tsx
@@ -151,12 +151,14 @@ export function Head({ data }: HeadProps<Queries.MemberPageQuery>) {
         undefined
       }
       linkedData={{
-        "@type": "Person",
-        name: nameJa,
-        alternateName: nameEn,
-        image:
-          data.mdx?.frontmatter?.upperBodyImage?.childImageSharp?.resize?.src ??
-          undefined,
+        "@context": "https://schema.org",
+        "@type": "ProfilePage",
+        mainEntity: {
+          "@type": "Person",
+          name: nameJa,
+          alternateName: nameEn,
+          image: data.mdx?.frontmatter?.upperBodyImage?.publicURL ?? undefined,
+        },
       }}
     />
   );
@@ -183,6 +185,7 @@ export const query = graphql`
           }
         }
         upperBodyImage {
+          publicURL
           childImageSharp {
             gatsbyImageData(
               width: 600

--- a/src/templates/project.tsx
+++ b/src/templates/project.tsx
@@ -98,7 +98,17 @@ export function Head({ data }: HeadProps<Queries.ProjectPageQuery>) {
       image={
         data.mdx?.frontmatter?.image?.childImageSharp?.resize?.src ?? undefined
       }
-      linkedData={{ "@type": "Product", name: title }}
+      linkedData={{
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        name: title,
+        offers: {
+          "@type": "Offer",
+          price: "0",
+        },
+        image: data.mdx?.frontmatter?.image?.publicURL ?? undefined,
+        aggregateRating: { "@type": "AggregateRating", reviewCount: 0 },
+      }}
     />
   );
 }
@@ -113,6 +123,7 @@ export const query = graphql`
         github
         website
         image {
+          publicURL
           childImageSharp {
             gatsbyImageData(
               width: 1200


### PR DESCRIPTION
- `@context` フィールドを追加 (ないと動かなかった)
- Google のドキュメントをもとに適切な type を設定
- 記事ページに画像を追加
- リサイズ済みの画像でなくオリジナル画像を渡すようにした
- トップページにもマークアップを追加