### PR TITLE
「プログラミング」というキーワードで検索に引っかかるようにしたい

### DIFF
--- a/src/components/CommonHead.tsx
+++ b/src/components/CommonHead.tsx
@@ -6,11 +6,13 @@ import config from "../../gatsby-config";
 export default function CommonHead({
   title,
   description,
+  keywords,
   image,
   linkedData,
 }: {
   title: string | null;
   description?: string;
+  keywords?: string[];
   image?: string;
   linkedData?: WithContext<Thing>;
 }) {
@@ -45,6 +47,16 @@ export default function CommonHead({
       <meta property="og:locale" content="ja_JP" />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@utokyo_code" />
+      <meta
+        name="keywords"
+        content={[
+          ...(keywords ?? []),
+          "ソフトウェアエンジニアリング",
+          "プログラミング",
+          "東京大学",
+          "サークル",
+        ].join(",")}
+      />
       {linkedData && (
         <script type="application/ld+json">{JSON.stringify(linkedData)}</script>
       )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -61,7 +61,8 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
               <div className="prose mt-3">
                 <p>
                   ut.code(); は、2019
-                  年設立の東京大学のソフトウェアエンジニアリングコミュニティです。
+                  年発足の東京大学のソフトウェアエンジニアリングコミュニティ・プログラミングサークルです。
+                  プログラミングの学習から、実社会で役立つソフトウェア製作まで、幅広い活動を行っています。
                 </p>
               </div>
               <ActionButton to="/join/" className="mt-4">


### PR DESCRIPTION
新入生等にとっては「プログラミング」というキーワードの方が「ソフトウェアエンジニアリング」という言葉よりも馴染み深い。「ソフトウェアエンジニアリング」の方が正確なのでそちらをメインにしつつ、地の文等でSEOに配慮する修正。

* 団体の説明文に「プログラミングサークル」というキーワードを追加
* meta keywords も追加