### PR TITLE
プロジェクトページにfaviconを追加

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "astro": "^5.7.12",
         "astro-icon": "^1.1.5",
         "bits-ui": "^1.4.8",
+        "cheerio": "^1.0.0",
         "daisyui": "^5.0.35",
         "date-fns": "^4.1.0",
         "markdown-to-txt": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "astro": "^5.7.12",
     "astro-icon": "^1.1.5",
     "bits-ui": "^1.4.8",
+    "cheerio": "^1.0.0",
     "daisyui": "^5.0.35",
     "date-fns": "^4.1.0",
     "markdown-to-txt": "^2.0.1",

--- a/src/pages/projects/[...id].astro
+++ b/src/pages/projects/[...id].astro
@@ -29,7 +29,8 @@ if (project.data.website && project.data.status !== "dead") {
     const iconHref = website("link[rel='icon'], link[rel='shortcut icon']")[0]
       ?.attribs.href;
     if (iconHref) {
-      iconSrc = new URL(iconHref, project.data.website).toString();
+      const faviconRes = await fetch(new URL(iconHref, project.data.website));
+      iconSrc = `data:${faviconRes.headers.get("content-type")};base64,${Buffer.from(await faviconRes.arrayBuffer()).toString("base64")}`;
     } else {
       const faviconRes = await fetch(
         `${new URL(project.data.website).origin}/favicon.ico`,
@@ -38,7 +39,7 @@ if (project.data.website && project.data.status !== "dead") {
         faviconRes.ok &&
         !faviconRes.headers.get("content-type")?.startsWith("text/")
       ) {
-        iconSrc = faviconRes.url;
+        iconSrc = `data:${faviconRes.headers.get("content-type")};base64,${Buffer.from(await faviconRes.arrayBuffer()).toString("base64")}`;
       }
     }
   }

--- a/src/pages/projects/[...id].astro
+++ b/src/pages/projects/[...id].astro
@@ -8,6 +8,7 @@ import { getProjects } from "+/query";
 import { Focus } from "+/schema.ts";
 import type { GetStaticPaths } from "astro";
 import { Icon } from "astro-icon/components";
+import { load as cheerioLoad } from "cheerio";
 
 export const getStaticPaths = (async () => {
   const projects = await getProjects("all");
@@ -18,6 +19,30 @@ export const getStaticPaths = (async () => {
 }) satisfies GetStaticPaths;
 const { project } = Astro.props;
 const { Content } = await render(project);
+
+let iconSrc: string | undefined = undefined;
+if (project.data.website && project.data.status !== "dead") {
+  const websiteRes = await fetch(project.data.website);
+  if (websiteRes.ok) {
+    const websiteHtml = await websiteRes.text();
+    const website = cheerioLoad(websiteHtml);
+    const iconHref = website("link[rel='icon'], link[rel='shortcut icon']")[0]
+      ?.attribs.href;
+    if (iconHref) {
+      iconSrc = new URL(iconHref, project.data.website).toString();
+    } else {
+      const faviconRes = await fetch(
+        `${new URL(project.data.website).origin}/favicon.ico`,
+      );
+      if (
+        faviconRes.ok &&
+        !faviconRes.headers.get("content-type")?.startsWith("text/")
+      ) {
+        iconSrc = faviconRes.url;
+      }
+    }
+  }
+}
 ---
 
 <GlobalLayout
@@ -95,7 +120,11 @@ const { Content } = await render(project);
         {
           project.data.website && project.data.status !== "dead" && (
             <ActionButton to={project.data.website} class="my-6">
-              <Icon name="feather:globe" class="mr-2 inline-block h-6 w-6" />
+              {iconSrc ? (
+                <img src={iconSrc} alt="favicon" class="inline-block h-6 w-6" />
+              ) : (
+                <Icon name="feather:globe" class="inline-block h-6 w-6" />
+              )}
               {project.data.title} へ
             </ActionButton>
           )


### PR DESCRIPTION
プロジェクトページからそれぞれのプロジェクトへ飛ぶボタンについている地球儀アイコンをそれぞれのfavicon﻿にすればいいのではと思った

ビルド時にリンク先のウェブサイトをfetchし、linkタグのicon指定が存在するか、または/favicon.icoが存在すればそれをアイコンのURLに指定する
