### PR TITLE
学園祭プロジェクトの順序がビルドのたびに変わるのを修正

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -10,7 +10,10 @@ export async function getProjects(kind: Kind | "all") {
       if (a_order !== b_order) {
         return a_order - b_order;
       }
-      return b.data.date.getTime() - a.data.date.getTime();
+      if (b.data.date.getTime() !== a.data.date.getTime()) {
+        return b.data.date.getTime() - a.data.date.getTime();
+      }
+      return (a.filePath ?? "") < (b.filePath ?? "") ? -1 : 1;
     });
 }
 


### PR DESCRIPTION
プロジェクトの日付が同じ場合の表示順が定義されていなかった。

