### PR TITLE
新歓イベント一覧の更新

### DIFF
--- a/src/pages/welcome-events.astro
+++ b/src/pages/welcome-events.astro
@@ -129,7 +129,8 @@ import { Picture } from "astro:assets";
       <li>発表会: 5/10 (日)</li>
       <li>
         <a href="https://forms.gle/KCQsJc5RAURUkFW8A"
-          >参加募集フォームはこちら</a>
+          >参加募集フォームはこちら</a
+        >
       </li>
     </ul>
   </section>

--- a/src/pages/welcome-events.astro
+++ b/src/pages/welcome-events.astro
@@ -99,63 +99,63 @@ import { Picture } from "astro:assets";
         <strong>飛び込み参加で大丈夫</strong>なのでいつでも気軽にお越しください!
       </section>
     </section>
+    <div class="divider">交流・開発系イベント</div>
+    <section>
+      <h3>新歓合宿</h3>
+      <ul>
+        <li>日程: 5/4 (月) ~ 5/6 (水)</li>
+        <li>
+          合宿を通してプログラミングの基礎を身につけ、自分なりのサイトやアプリを作りましょう！
+        </li>
+        <li>
+          ut.code(); の新歓イベントとしては一番大きなものになります！
+          <br />
+          ut.code(); の普段の活動を知ることができますし、部員や他の新入生とも交流できるいい機会になります！
+          ぜひご参加ください！
+        </li>
+        <li>
+          <a href="https://forms.gle/m2BV6YbAPkw4yXLq7"
+            >参加募集フォームはこちら</a
+          >
+        </li>
+      </ul>
+    </section>
+    <section>
+      <h3>新歓ハッカソン</h3>
+      <ul>
+        <li>キックオフ: 4/26 (日)</li>
+        <li>作業会: 5/9 (土)</li>
+        <li>発表会: 5/10 (日)</li>
+        <li>
+          <a href="https://forms.gle/KCQsJc5RAURUkFW8A"
+            >参加募集フォームはこちら</a
+          >
+        </li>
+      </ul>
+    </section>
+    <div class="divider">その他</div>
+    <section>
+      <h3>ut.code(); 総会</h3>
+      <ul>
+        <li>4月総会: 4/25 (土)</li>
+        <li>5月総会: 5/16 (土)</li>
+      </ul>
+    </section>
+    <div class="divider"></div>
+    <p>
+      さらに詳しい連絡は、Discord
+      で行いますので、興味がある方はぜひ参加してみてください！
+    </p>
+    <p>
+      <a href="https://discord.gg/JvhPrySrJE"> Discord 参加リンクはこちら </a>
+    </p>
+    <style>
+      section {
+        margin-top: 3rem;
+      }
+      .divider {
+        color: var(--color-gray-600);
+      }
+    </style>
   </StaticDocumentWrapper>
-  <div class="divider">交流・開発系イベント</div>
-  <section>
-    <h3>新歓合宿</h3>
-    <ul>
-      <li>日程: 5/4 (月) ~ 5/6 (水)</li>
-      <li>
-        合宿を通してプログラミングの基礎を身につけ、自分なりのサイトやアプリを作りましょう！
-      </li>
-      <li>
-        ut.code(); の新歓イベントとしては一番大きなものになります！
-        <br />
-        ut.code(); の普段の活動を知ることができますし、部員や他の新入生とも交流できるいい機会になります！
-        ぜひご参加ください！
-      </li>
-      <li>
-        <a href="https://forms.gle/m2BV6YbAPkw4yXLq7"
-          >参加募集フォームはこちら</a
-        >
-      </li>
-    </ul>
-  </section>
-  <section>
-    <h3>新歓ハッカソン</h3>
-    <ul>
-      <li>キックオフ: 4/26 (日)</li>
-      <li>作業会: 5/9 (土)</li>
-      <li>発表会: 5/10 (日)</li>
-      <li>
-        <a href="https://forms.gle/KCQsJc5RAURUkFW8A"
-          >参加募集フォームはこちら</a
-        >
-      </li>
-    </ul>
-  </section>
-  <div class="divider">その他</div>
-  <section>
-    <h3>ut.code(); 総会</h3>
-    <ul>
-      <li>4月総会: 4/25 (土)</li>
-      <li>5月総会: 5/16 (土)</li>
-    </ul>
-  </section>
-  <div class="divider"></div>
-  <p>
-    さらに詳しい連絡は、Discord
-    で行いますので、興味がある方はぜひ参加してみてください！
-  </p>
-  <p>
-    <a href="https://discord.gg/JvhPrySrJE"> Discord 参加リンクはこちら </a>
-  </p>
 </GlobalLayout>
-<style>
-  section {
-    margin-top: 3rem;
-  }
-  .divider {
-    color: var(--color-gray-600);
-  }
-</style>

--- a/src/pages/welcome-events.astro
+++ b/src/pages/welcome-events.astro
@@ -26,6 +26,7 @@ import { Picture } from "astro:assets";
         興味がある方は、ぜひ気軽に参加してみてください！
       </p>
       <p>日時・場所の詳細は確定し次第追加します。</p>
+      <p>（2026/4/12更新）</p>
       <a
         href="/welcome-events-calendar/calendar.jpg"
         target="_blank"
@@ -60,10 +61,24 @@ import { Picture } from "astro:assets";
       <section id="beginners-seminar">
         <h3>初学者講習会</h3>
         <ul>
-          <li>日時: 4/12 (日), 4/18 (土)</li>
+          <li>
+            日時: 4/12 (日), 4/18 (土)　それぞれ<strong>13:30～17:30</strong>
+          </li>
+          <li>
+            場所:
+            <ul>
+              <li>4/12(日): 1311教室</li>
+              <li>4/18(土): 1331教室</li>
+            </ul>
+          </li>
           <li>
             授業形式で HTML・CSS・JavaScript の基礎を学び、簡単な Web
             アプリを公開できるようになります。
+          </li>
+          <li>
+            <a href="https://forms.gle/HPi8Y73h4xFjQTAs5"
+              >参加募集フォームはこちら</a
+            >
           </li>
         </ul>
       </section>
@@ -74,54 +89,72 @@ import { Picture } from "astro:assets";
             日時: 4/7 (火), 4/10 (金), 4/14 (火), 4/17 (金), 4/21 (火), 4/24
             (金), 4/28 (火), 5/8 (金)
           </li>
+          <li>場所: <strong>学生会館 313B教室</strong></li>
           <li>途中参加・途中退出可。</li>
           <li>
             自分のペースでプログラミングを学び、プロジェクトに参加できるスキルをつけよう！
-            経験者も新しい知識を学ぶチャンス！
           </li>
+          経験者も新しい知識を学ぶチャンス！ 教材のことやサークルについてのこと、履修相談など何でも質問可能です。
         </ul>
-      </section>
-      <div class="divider">交流・開発系イベント</div>
-      <section>
-        <h3>新歓合宿</h3>
-        <ul>
-          <li>日程: 5/4 (月) ~ 5/6 (水)</li>
-          <li>
-            合宿を通してプログラミングの基礎を身につけ、自分なりのサイトやアプリを作りましょう！
-          </li>
-          <li>
-            ut.code(); の新歓イベントとしては一番大きなものになります！
-            <br />
-            ut.code(); の普段の活動を知ることができますし、部員や他の新入生とも交流できるいい機会になります！
-            ぜひご参加ください！
-          </li>
-        </ul>
-      </section>
-      <section>
-        <h3>新歓ハッカソン</h3>
-        <ul>
-          <li>キックオフ: 4/26 (日)</li>
-          <li>作業会: 5/9 (土)</li>
-          <li>発表会: 5/10 (日)</li>
-        </ul>
-      </section>
-      <div class="divider">その他</div>
-      <section>
-        <h3>ut.code(); 総会</h3>
-        <ul>
-          <li>4月総会: 4/25 (土)</li>
-          <li>5月総会: 5/16 (土)</li>
-        </ul>
+        <strong>飛び込み参加で大丈夫</strong>なのでいつでも気軽にお越しください!
       </section>
     </section>
-
-    <style>
-      section {
-        margin-top: 3rem;
-      }
-      .divider {
-        color: var(--color-gray-600);
-      }
-    </style>
   </StaticDocumentWrapper>
+  <div class="divider">交流・開発系イベント</div>
+  <section>
+    <h3>新歓合宿</h3>
+    <ul>
+      <li>日程: 5/4 (月) ~ 5/6 (水)</li>
+      <li>
+        合宿を通してプログラミングの基礎を身につけ、自分なりのサイトやアプリを作りましょう！
+      </li>
+      <li>
+        ut.code(); の新歓イベントとしては一番大きなものになります！
+        <br />
+        ut.code(); の普段の活動を知ることができますし、部員や他の新入生とも交流できるいい機会になります！
+        ぜひご参加ください！
+      </li>
+      <li>
+        <a href="https://forms.gle/m2BV6YbAPkw4yXLq7"
+          >参加募集フォームはこちら</a
+        >
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3>新歓ハッカソン</h3>
+    <ul>
+      <li>キックオフ: 4/26 (日)</li>
+      <li>作業会: 5/9 (土)</li>
+      <li>発表会: 5/10 (日)</li>
+      <li>
+        <a href="https://forms.gle/KCQsJc5RAURUkFW8A"
+          >参加募集フォームはこちら</a>
+      </li>
+    </ul>
+  </section>
+  <div class="divider">その他</div>
+  <section>
+    <h3>ut.code(); 総会</h3>
+    <ul>
+      <li>4月総会: 4/25 (土)</li>
+      <li>5月総会: 5/16 (土)</li>
+    </ul>
+  </section>
+  <div class="divider"></div>
+  <p>
+    さらに詳しい連絡は、Discord
+    で行いますので、興味がある方はぜひ参加してみてください！
+  </p>
+  <p>
+    <a href="https://discord.gg/JvhPrySrJE"> Discord 参加リンクはこちら </a>
+  </p>
 </GlobalLayout>
+<style>
+  section {
+    margin-top: 3rem;
+  }
+  .divider {
+    color: var(--color-gray-600);
+  }
+</style>


### PR DESCRIPTION
新歓イベントの詳細情報や参加フォームがWeb上からではアクセスできない状態だったので、それらの情報を追記しました。
Ｄiscordのリンクも再掲しています。