### PR TITLE
プロジェクトページからリンクするサイトへのnoreferrerを削除

### DIFF
--- a/src/components/utils/ActionButton.astro
+++ b/src/components/utils/ActionButton.astro
@@ -13,7 +13,7 @@ const { to, variant = "dark" } = props;
 
 <a
   href={to}
-  {...!to.startsWith("/") ? { target: "_blank", rel: "" } : {}}
+  {...!to.startsWith("/") ? { target: "_blank", rel: "noopener" } : {}}
   class:list={[
     "not-prose relative flex w-max items-center gap-4 rounded-full bg-gray-50 px-6 py-3 font-bold text-black hover:brightness-95 active:top-0.25",
     variant === "dark" && "border border-black",

--- a/src/components/utils/ActionButton.astro
+++ b/src/components/utils/ActionButton.astro
@@ -13,7 +13,7 @@ const { to, variant = "dark" } = props;
 
 <a
   href={to}
-  {...!to.startsWith("/") ? { target: "_blank", rel: "noreferrer" } : {}}
+  {...!to.startsWith("/") ? { target: "_blank", rel: "" } : {}}
   class:list={[
     "not-prose relative flex w-max items-center gap-4 rounded-full bg-gray-50 px-6 py-3 font-bold text-black hover:brightness-95 active:top-0.25",
     variant === "dark" && "border border-black",

--- a/src/pages/projects/[...id].astro
+++ b/src/pages/projects/[...id].astro
@@ -120,7 +120,7 @@ if (project.data.status !== "dead") {
                     href={link.href}
                     target="_blank"
                     class="-m-1 mt-6 rounded-xl p-1 hover:brightness-95"
-                    rel="noreferrer"
+                    rel=""
                     aria-label={`${link.label}を見る`}
                   >
                     <Icon name={link.icon} class="h-9 w-9" />

--- a/src/pages/projects/[...id].astro
+++ b/src/pages/projects/[...id].astro
@@ -120,7 +120,7 @@ if (project.data.status !== "dead") {
                     href={link.href}
                     target="_blank"
                     class="-m-1 mt-6 rounded-xl p-1 hover:brightness-95"
-                    rel=""
+                    rel="noopener"
                     aria-label={`${link.label}を見る`}
                   >
                     <Icon name={link.icon} class="h-9 w-9" />


### PR DESCRIPTION
特にutcode.net→プロジェクトのサイトへのリンクの際、アナリティクスを分析するのにreferrerがあったほうが良い
ソーシャルリンクに関してはどっちでもいいかもですが

例えば ↓ の direct は実はutcode.netなのでは? とか
<img width="395" height="251" alt="image" src="https://github.com/user-attachments/assets/408707cd-9dd8-4fc3-b7e4-91cb7c5ea500" />


